### PR TITLE
Set options depending on subproject status.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,16 @@ set(HADOKEN_VERSION_MAJOR "1")
 set(HADOKEN_VERSION_MINOR "")
 add_definitions( -DHADOKEN_VERSION_MAJOR=\"${HADOKEN_VERSION_MAJOR}\" -DHADOKEN_VERSION_MINOR=\"${HADOKEN_VERSION_MINOR}\")
 
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  set(CUR_PROJ ON)
+else()
+  set(CUR_PROJ OFF)
+endif()
 
-option(HADOKEN_DISABLE_INSTALL "Disable the installation for this component" TRUE)
-option(HADOKEN_UNIT_TESTS "Enable or disable unit tests execution" TRUE)
-option(HADOKEN_PERF_TESTS "Enable or disable performance tests execution" FALSE)
+include(CMakeDependentOption)
+cmake_dependent_option(HADOKEN_DISABLE_INSTALL "Disable the installation for this component" ON "CUR_PROJ" ON)
+cmake_dependent_option(HADOKEN_UNIT_TESTS "Enable or disable unit tests execution" ON "CUR_PROJ" OFF)
+cmake_dependent_option(HADOKEN_PERF_TESTS "Enable or disable performance tests execution" OFF "CUR_PROJ" OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake
       ${PROJECT_SOURCE_DIR}/CMake/portability


### PR DESCRIPTION
When using
```
add_subdirectory(${CMAKE_SOURCE_DIR}/deps/hadoken)
```
in our own `CMakeLists.txt`, unit tests automatically get included in the parent project. I think that Hadoken should only run unit tests when explicitly asked or run on its own.