### PR TITLE
Minor fixes to small_vector

### DIFF
--- a/include/hadoken/containers/bits/small_vector_bits.hpp
+++ b/include/hadoken/containers/bits/small_vector_bits.hpp
@@ -171,6 +171,12 @@ typename small_vector<T, N>::reference small_vector<T, N>::back() {
 }
 
 template <typename T, std::size_t N>
+typename small_vector<T, N>::const_reference small_vector<T, N>::back() const noexcept {
+    assert((_end - _begin) >= 1);
+    return *((std::max(_begin, _end - 1)));
+}
+
+template <typename T, std::size_t N>
 typename small_vector<T, N>::pointer small_vector<T, N>::data() noexcept {
     return &(*_begin);
 }
@@ -198,7 +204,7 @@ typename small_vector<T, N>::reference small_vector<T, N>::operator[](std::size_
 template <typename T, std::size_t N>
 typename small_vector<T, N>::const_reference small_vector<T, N>::operator[](std::size_t pos) const noexcept {
     assert(std::ptrdiff_t(pos) < (_end - _begin));
-    return _begin + static_cast<std::ptrdiff_t>(pos);
+    return *(_begin + static_cast<std::ptrdiff_t>(pos));
 }
 
 

--- a/include/hadoken/containers/small_vector.hpp
+++ b/include/hadoken/containers/small_vector.hpp
@@ -33,7 +33,6 @@
 #include <memory>
 
 
-#include <boost/type_traits.hpp>
 
 #include "ptr_iterator.hpp"
 
@@ -57,8 +56,8 @@ class small_vector {
 
     // not implemented now
     //    typedef std::reverse_iterator<const_iterator>  const_reverse_iterator;
-    //    typedef std::reverse_iterator<iterator>		 reverse_iterator;
-    //    typedef _Alloc                        		 allocator_type;
+    //    typedef std::reverse_iterator<iterator>        reverse_iterator;
+    //    typedef _Alloc                                 allocator_type;
 
     ///
     /// \brief default constructor, empty small_vector
@@ -134,7 +133,16 @@ class small_vector {
     ///
     const_reference front() const noexcept;
 
+    ///
+    /// \brief back
+    /// \return reference to the last element of the vector
+    ///
+    const_reference back() const noexcept;
 
+    ///
+    /// \brief back
+    /// \return reference to the last element of the vector
+    ///
     reference& back();
 
     ///


### PR DESCRIPTION
Added const `back()` and fixed const `operator[]`. Also removed unused boost dependency.

When using it I noticed that `clear()` and `resize(size_t, T const&)` are not implemented, but can be worked around.